### PR TITLE
Fix database and dependency conflicts for local development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,11 @@ dependencies = [
     "fastapi==0.110.0",
     "uvicorn==0.27.1",
     "pydantic==2.6.1",
-    "fastapi-users[sqlalchemy,oauth]==12.1.3",
+    "fastapi-users[sqlalchemy,oauth]==13.0.0",
     "httpx-oauth==0.13.0",
     "python-jose[cryptography]==3.3.0",
     "asyncpg==0.29.0",
+    "aiosqlite==0.19.0",
     "sqlalchemy[asyncio]==2.0.27",
     "alembic==1.13.1"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ fastapi==0.110.0
 uvicorn==0.27.1
 pydantic==2.6.1
 sqlalchemy==2.0.27
-fastapi-users[sqlalchemy]==12.1.2 
+fastapi-users[sqlalchemy]==13.0.0
+aiosqlite==0.19.0 

--- a/tutor_stack_auth/auth.py
+++ b/tutor_stack_auth/auth.py
@@ -13,8 +13,8 @@ from typing import Optional
 import uuid
 
 # JWT Configuration
-SECRET_PRIVATE_KEY_PATH = os.getenv("SECRET_PRIVATE_KEY_PATH", "/keys/jwtRS256.key")
-SECRET_PUBLIC_KEY_PATH = os.getenv("SECRET_PUBLIC_KEY_PATH", "/keys/jwtRS256.key.pub")
+SECRET_PRIVATE_KEY_PATH = os.getenv("SECRET_PRIVATE_KEY_PATH", "./keys/jwtRS256.key")
+SECRET_PUBLIC_KEY_PATH = os.getenv("SECRET_PUBLIC_KEY_PATH", "./keys/jwtRS256.key.pub")
 
 SECRET = os.getenv("SECRET_KEY", "dev-secret-key-change-in-production")
 

--- a/tutor_stack_auth/database.py
+++ b/tutor_stack_auth/database.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 import os
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql+asyncpg://tutor:tutor@localhost:5432/tutor_auth")
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./tutor_auth.db")
 
 engine = create_async_engine(DATABASE_URL, echo=True)
 async_session_maker = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/tutor_stack_auth/main.py
+++ b/tutor_stack_auth/main.py
@@ -76,7 +76,7 @@ if GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET:
     
     # Get the private key for OAuth
     try:
-        with open(os.getenv("SECRET_PRIVATE_KEY_PATH", "/keys/jwtRS256.key"), "r") as f:
+        with open(os.getenv("SECRET_PRIVATE_KEY_PATH", "./keys/jwtRS256.key"), "r") as f:
             secret = f.read()
     except FileNotFoundError:
         secret = "dev-secret-key-change-in-production"


### PR DESCRIPTION
- Update default DATABASE_URL to use SQLite instead of PostgreSQL
- Add aiosqlite dependency for SQLite async support
- Update fastapi-users to version 13.0.0 for pyjwt 2.8.0 compatibility
- Fix JWT key paths to use relative paths for local development
- Resolve dependency conflicts between pyjwt versions